### PR TITLE
feat: add control slider for editing mod values

### DIFF
--- a/src/CustomStyle.js
+++ b/src/CustomStyle.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import Sketch from 'react-p5';
 import MersenneTwister from 'mersenne-twister';
 

--- a/src/components/ControlColorPicker.js
+++ b/src/components/ControlColorPicker.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const ControlColorPicker = function (props) {
+    const handleColorChange = event => {
+        props.onChange(event.target.value)
+    }
+
+    return (
+        <div style={{'marginBottom': '10px'}}>
+            <label style={{'display': 'block'}}>{props.controlLabel}</label>
+            <input
+                id="controlColorPicker"
+                type="color"
+                defaultValue={props.modValue}
+                onInput={handleColorChange}
+            />
+        </div>
+    );
+}
+export default ControlColorPicker;

--- a/src/components/ControlSlider.js
+++ b/src/components/ControlSlider.js
@@ -8,14 +8,14 @@ const ControlSlider = function (props) {
     return (
         <div style={{'marginBottom': '10px'}}>
             <label style={{'display': 'block'}}>{props.controlLabel}</label>
-            <div style={{'display': 'inline'}}>{props.modValue}</div>
+            <div style={{'display': 'inline-flex', 'width': '40px'}}>{props.modValue}</div>
             <input
                 id="controlSlider"
                 type="range"
                 min={props.modValueMin || 0 } 
                 max={props.modValueMax || 1} 
                 defaultValue={props.modValue || 0.5} 
-                step={props.modValueStep || 0.01}
+                step={props.modValueStep || 0.001}
                 onChange={handleModChange} 
 
             />

--- a/src/components/ControlSlider.js
+++ b/src/components/ControlSlider.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const ControlSlider = function (props) {
+    const handleModChange = event => {
+        props.onChange(event.target.value)
+    }
+
+    return (
+        <div style={{'marginBottom': '10px'}}>
+            <label style={{'display': 'block'}}>{props.controlLabel}</label>
+            <div style={{'display': 'inline'}}>{props.modValue}</div>
+            <input
+                id="controlSlider"
+                type="range"
+                min={props.modValueMin || 0 } 
+                max={props.modValueMax || 1} 
+                defaultValue={props.modValue || 0.5} 
+                step={props.modValueStep || 0.01}
+                onChange={handleModChange} 
+
+            />
+        </div>
+    );
+}
+export default ControlSlider;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import useDimensions from 'react-cool-dimensions';
 import blocks from './blocks';
 import CustomStyle from './CustomStyle';
 import ControlSlider from './components/ControlSlider';
+import ControlColorPicker from './components/ControlColorPicker';
 
 function App() {
   /*
@@ -11,7 +12,20 @@ function App() {
   As a creative coder, in this file you can swap between the block data provided on line 40
   For the rest, you can ignore this file, check CustomStyle.js
 */
-  const [blockNumber, setBlockNumber] = useState(2);
+  const defaultBlockNumber = 2;
+  const defaultBackgroundColor = '#eeeeee';
+
+  const [blockNumber, setBlockNumber] = useState(defaultBlockNumber);
+  const [backgroundColor, setBackgroundColor] = useState(defaultBackgroundColor);
+
+  // MOD1 EXAMPLE
+  // Example of state for mod1 control, if you want to create more mod controls,
+  // copy paste related lines and change "mod1" to "modX" where X is current mod#+1
+  // const defaultMod1Value = 0.5 // set this to something in between 0 and 1
+  // const [mod1, setMod1] = useState(defaultMod1Value);
+  // Lastly, ensure that you are using Mod1 somewhere in the CustomStyle to affect the drawing
+
+
   function changeModValue(modSetFunction, e) {
     modSetFunction(e)
   }
@@ -42,14 +56,27 @@ function App() {
         modValueStep="1"
         onChange={(e) => { changeModValue(setBlockNumber, e) }}
       />
+      <ControlColorPicker 
+        controlLabel="Background Color"
+        modValue={backgroundColor}
+        onChange={(e) => { changeModValue(setBackgroundColor, e) }}
+      />
+      {/* MOD1 EXAMPLE */}
+      {/* <ControlSlider
+        controlLabel="Mod1"
+        modValue={mod1}
+        onChange={(e) => { changeModValue(setMod1, e) }}
+      /> */}
       {width && height ? (
         <CustomStyle
           width={width}
-          block={blocks[blockNumber-1]} // Example: Change "block = block[0]" to block[1] or block[2] to see how different blocks look with the code written
+          block={blocks[blockNumber-1]}
           height={height}
           canvasRef={canvasRef}
           attributesRef={attributesRef}
           handleResize={_onCanvasResize}
+          background={backgroundColor}
+          // mod1={mod1} // MOD1 EXAMPLE
         />
       ) : null}
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import React, { useRef, useState } from 'react';
 import useDimensions from 'react-cool-dimensions';
 import blocks from './blocks';
 import CustomStyle from './CustomStyle';
+import ControlSlider from './components/ControlSlider';
 
 function App() {
   /*
@@ -10,6 +11,11 @@ function App() {
   As a creative coder, in this file you can swap between the block data provided on line 40
   For the rest, you can ignore this file, check CustomStyle.js
 */
+  const [blockNumber, setBlockNumber] = useState(2);
+  function changeModValue(modSetFunction, e) {
+    modSetFunction(e)
+  }
+
   const canvasRef = useRef();
   const attributesRef = useRef();
   const { ref, width, height } = useDimensions({});
@@ -28,10 +34,18 @@ function App() {
       }}
     >
       <p>EthBlock.art P5.js boilerplate</p>
+      <ControlSlider
+        controlLabel="Block"
+        modValue={blockNumber}
+        modValueMin="1"
+        modValueMax={blocks.length}
+        modValueStep="1"
+        onChange={(e) => { changeModValue(setBlockNumber, e) }}
+      />
       {width && height ? (
         <CustomStyle
           width={width}
-          block={blocks[1]} // Example: Change "block = block[0]" to block[1] or block[2] to see how different blocks look with the code written
+          block={blocks[blockNumber-1]} // Example: Change "block = block[0]" to block[1] or block[2] to see how different blocks look with the code written
           height={height}
           canvasRef={canvasRef}
           attributesRef={attributesRef}


### PR DESCRIPTION
A ControlSlider component has been added to allow for the easy modification of mod values, attributes (such as block), etc. The default example allows the selection of the block.
![image](https://user-images.githubusercontent.com/27592/103546280-05ddf480-4ea3-11eb-9a61-7cd8a6757a11.png)
![image](https://user-images.githubusercontent.com/27592/103546296-0aa2a880-4ea3-11eb-88da-766039d340cb.png)
