### PR TITLE
Basic theming and controls sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,16 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <style>
+      body {
+        background-color: #fff;
+        font-family: 'Courier New', Courier, monospace;
+        font-size: 13px;
+        font-weight: bold;
+        padding: 0px;
+        margin: 0px;
+      }
+    </style>
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -24,7 +34,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>ETHBlock</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/CustomStyle.js
+++ b/src/CustomStyle.js
@@ -8,7 +8,7 @@ Create your Custom style to be turned into a EthBlock.art Mother NFT
 Basic rules:
  - use a minimum of 1 and a maximum of 4 "modifiers", modifiers are values between 0 and 1,
  - use a minimum of 1 and a maximum of 3 colors, the color "background" will be set at the canvas root
- - Use the block as source of entropy, no Math.random() allowed! 
+ - Use the block as source of entropy, no Math.random() allowed!
  - You can use a "shuffle bag" using data from the block as seed, a MersenneTwister library is provided
 
  Arguments:
@@ -43,7 +43,7 @@ const CustomStyle = ({
 }) => {
   const shuffleBag = useRef();
   const hoistedValue = useRef();
- 
+
   const { hash } = block;
 
   // setup() initializes p5 and the canvas element, can be mostly ignored in our case (check draw())
@@ -58,19 +58,19 @@ const CustomStyle = ({
         // should return an object structured following opensea/enjin metadata spec for attributes/properties
         // https://docs.opensea.io/docs/metadata-standards
         // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1155.md#erc-1155-metadata-uri-json-schema
-       
+
        attributes: [
           {
             display_type: 'number',
             trait_type: 'your trait here number',
             value: hoistedValue.current, // using the hoisted value from within the draw() method, stored in the ref.
           },
-         
+
           {
             trait_type: 'your trait here text',
             value: "replace me",
           },
-          
+
         ],
       };
     };
@@ -104,13 +104,13 @@ const CustomStyle = ({
         radius: seed / 1000000000000000,
       };
     });
-   
+
     // example assignment of hoisted value to be used as NFT attribute later
    hoistedValue.current = 42;
-   
+
     objs.map((dot, i) => {
       p5.stroke(color1);
-      p5.strokeWeight(1);
+      p5.strokeWeight(1 + (mod2 * 10));
       p5.ellipse(
         200 * dot.y * 6 * M,
         100 * dot.x * 6 * M,

--- a/src/components/ControlColorPicker.js
+++ b/src/components/ControlColorPicker.js
@@ -6,8 +6,8 @@ const ControlColorPicker = function (props) {
     }
 
     return (
-        <div style={{'marginBottom': '10px'}}>
-            <label style={{'display': 'block'}}>{props.controlLabel}</label>
+        <div style={{'margin': '5px 0', 'font-size': '11px'}}>
+            <label style={{'display': 'block', 'margin-bottom': '4px' }}>{props.controlLabel}</label>
             <input
                 id="controlColorPicker"
                 type="color"

--- a/src/components/ControlSlider.css
+++ b/src/components/ControlSlider.css
@@ -1,0 +1,110 @@
+.control-slider {
+  margin: 5px 0;
+  font-size: 11px;
+}
+
+.control-slider label {
+  display: block;
+}
+.control-slider .control-input {
+  display: flex;
+}
+
+.control-slider .value-label {
+  font-size: 11px;
+  width: 50px;
+  height: 16px;
+  line-height: 16px;
+  margin: 8px 0;
+}
+
+.control-slider input[type=range] {
+  flex-grow: 1;
+  height: 21px;
+  -webkit-appearance: none;
+  margin: 6px 0;
+  width: 100%;
+}
+.control-slider input[type=range]:focus {
+  outline: none;
+}
+.control-slider input[type=range]::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 5px;
+  cursor: pointer;
+  animate: 0.2s;
+  box-shadow: 0px 0px 0px #000000;
+  background: #6C6C6C;
+  border-radius: 5px;
+  border: 0px solid #000000;
+}
+.control-slider input[type=range]::-webkit-slider-thumb {
+  box-shadow: 0px 0px 0px #000000;
+  border: 0px solid #000000;
+  height: 15px;
+  width: 15px;
+  border-radius: 8px;
+  background: #000000;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-top: -5px;
+}
+.control-slider input[type=range]:focus::-webkit-slider-runnable-track {
+  background: #6C6C6C;
+}
+.control-slider input[type=range]::-moz-range-track {
+  width: 100%;
+  height: 5px;
+  cursor: pointer;
+  animate: 0.2s;
+  box-shadow: 0px 0px 0px #000000;
+  background: #6C6C6C;
+  border-radius: 5px;
+  border: 0px solid #000000;
+}
+.control-slider input[type=range]::-moz-range-thumb {
+  box-shadow: 0px 0px 0px #000000;
+  border: 0px solid #000000;
+  height: 15px;
+  width: 15px;
+  border-radius: 8px;
+  background: #000000;
+  cursor: pointer;
+}
+.control-slider input[type=range]::-ms-track {
+  width: 100%;
+  height: 5px;
+  cursor: pointer;
+  animate: 0.2s;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}
+.control-slider input[type=range]::-ms-fill-lower {
+  background: #6C6C6C;
+  border: 0px solid #000000;
+  border-radius: 10px;
+  box-shadow: 0px 0px 0px #000000;
+}
+.control-slider input[type=range]::-ms-fill-upper {
+  background: #6C6C6C;
+  border: 0px solid #000000;
+  border-radius: 10px;
+  box-shadow: 0px 0px 0px #000000;
+}
+.control-slider input[type=range]::-ms-thumb {
+  margin-top: 1px;
+  box-shadow: 0px 0px 0px #000000;
+  border: 0px solid #000000;
+  height: 15px;
+  width: 15px;
+  border-radius: 8px;
+  background: #000000;
+  cursor: pointer;
+}
+.control-slider input[type=range]:focus::-ms-fill-lower {
+  background: #6C6C6C;
+}
+.control-slider input[type=range]:focus::-ms-fill-upper {
+  background: #6C6C6C;
+}

--- a/src/components/ControlSlider.js
+++ b/src/components/ControlSlider.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import './ControlSlider.css'
 
 const ControlSlider = function (props) {
     const handleModChange = event => {
@@ -6,19 +7,20 @@ const ControlSlider = function (props) {
     }
 
     return (
-        <div style={{'marginBottom': '10px'}}>
-            <label style={{'display': 'block'}}>{props.controlLabel}</label>
-            <div style={{'display': 'inline-flex', 'width': '40px'}}>{props.modValue}</div>
-            <input
-                id="controlSlider"
-                type="range"
-                min={props.modValueMin || 0 } 
-                max={props.modValueMax || 1} 
-                defaultValue={props.modValue || 0.5} 
-                step={props.modValueStep || 0.001}
-                onChange={handleModChange} 
-
-            />
+        <div className={'control-slider'}>
+            <label>{props.controlLabel}</label>
+            <div className={'control-input'}>
+                <div className={'value-label'}>{props.modValue}</div>
+                <input
+                    id="controlSlider"
+                    type="range"
+                    min={props.modValueMin || 0 }
+                    max={props.modValueMax || 1}
+                    defaultValue={props.modValue || 0.5}
+                    step={props.modValueStep || 0.001}
+                    onChange={handleModChange}
+                />
+            </div>
         </div>
     );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,18 +13,14 @@ function App() {
   For the rest, you can ignore this file, check CustomStyle.js
 */
   const defaultBlockNumber = 2;
+  const defaultMod1Value = 0.33;
+  const defaultMod2Value = 0.66;
   const defaultBackgroundColor = '#eeeeee';
 
   const [blockNumber, setBlockNumber] = useState(defaultBlockNumber);
+  const [mod1, setMod1] = useState(defaultMod1Value);
+  const [mod2, setMod2] = useState(defaultMod2Value);
   const [backgroundColor, setBackgroundColor] = useState(defaultBackgroundColor);
-
-  // MOD1 EXAMPLE
-  // Example of state for mod1 control, if you want to create more mod controls,
-  // copy paste related lines and change "mod1" to "modX" where X is current mod#+1
-  // const defaultMod1Value = 0.5 // set this to something in between 0 and 1
-  // const [mod1, setMod1] = useState(defaultMod1Value);
-  // Lastly, ensure that you are using Mod1 somewhere in the CustomStyle to affect the drawing
-
 
   function changeModValue(modSetFunction, e) {
     modSetFunction(e)
@@ -38,47 +34,71 @@ function App() {
   };
 
   return (
-    <div
-      ref={ref}
-      style={{
-        margin: '0 auto',
-        marginTop: '64px',
-        width: '60vw',
-        height: '60vw',
-      }}
-    >
-      <p>EthBlock.art P5.js boilerplate</p>
-      <ControlSlider
-        controlLabel="Block"
-        modValue={blockNumber}
-        modValueMin="1"
-        modValueMax={blocks.length}
-        modValueStep="1"
-        onChange={(e) => { changeModValue(setBlockNumber, e) }}
-      />
-      <ControlColorPicker 
-        controlLabel="Background Color"
-        modValue={backgroundColor}
-        onChange={(e) => { changeModValue(setBackgroundColor, e) }}
-      />
-      {/* MOD1 EXAMPLE */}
-      {/* <ControlSlider
-        controlLabel="Mod1"
-        modValue={mod1}
-        onChange={(e) => { changeModValue(setMod1, e) }}
-      /> */}
-      {width && height ? (
-        <CustomStyle
-          width={width}
-          block={blocks[blockNumber-1]}
-          height={height}
-          canvasRef={canvasRef}
-          attributesRef={attributesRef}
-          handleResize={_onCanvasResize}
-          background={backgroundColor}
-          // mod1={mod1} // MOD1 EXAMPLE
-        />
-      ) : null}
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <div style={{ flexGrow: 1 }}>
+        <div
+          ref={ref}
+          style={{
+            margin: '0 auto',
+            marginTop: '64px',
+            width: '60vw',
+            height: '60vw'
+          }}
+        >
+          <p>EthBlock.art P5.js boilerplate</p>
+          {width && height ? (
+            <CustomStyle
+              width={width}
+              block={blocks[blockNumber-1]}
+              height={height}
+              canvasRef={canvasRef}
+              attributesRef={attributesRef}
+              handleResize={_onCanvasResize}
+              background={backgroundColor}
+              mod1={mod1}
+              mod2={mod2}
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <div
+        style={{
+          width: '200px',
+          borderLeft: '#e0e0e0 1px solid',
+          backgroundColor: '#fff'
+        }}
+      >
+        <div style={{ height: '40px', background: '#000', color: '#fff', lineHeight: '40px', textAlign: 'center' }}>Change Block</div>
+        <div style={{ padding: '20px' }}>
+          <ControlSlider
+            modValue={blockNumber}
+            modValueMin="1"
+            modValueMax={blocks.length}
+            modValueStep="1"
+            onChange={(e) => { changeModValue(setBlockNumber, e) }}
+          />
+        </div>
+
+        <div style={{ height: '40px', background: '#000', color: '#fff', lineHeight: '40px', textAlign: 'center' }}>Change Style</div>
+        <div style={{ padding: '20px' }}>
+          {<ControlSlider
+            controlLabel="mod1"
+            modValue={mod1}
+            onChange={(e) => { changeModValue(setMod1, e) }}
+          />}
+          {<ControlSlider
+            controlLabel="mod2"
+            modValue={mod2}
+            onChange={(e) => { changeModValue(setMod2, e) }}
+          />}
+          <ControlColorPicker
+            controlLabel="background"
+            modValue={backgroundColor}
+            onChange={(e) => { changeModValue(setBackgroundColor, e) }}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ function App() {
   For the rest, you can ignore this file, check CustomStyle.js
 */
   const defaultBlockNumber = 2;
-  const defaultMod1Value = 0.33;
-  const defaultMod2Value = 0.66;
-  const defaultBackgroundColor = '#eeeeee';
+  const defaultMod1Value = 0.75;
+  const defaultMod2Value = 0.25;
+  const defaultBackgroundColor = '#cccccc';
 
   const [blockNumber, setBlockNumber] = useState(defaultBlockNumber);
   const [mod1, setMod1] = useState(defaultMod1Value);


### PR DESCRIPTION
Proposing a theme for the p5js Ethblock boilerplate code similar to the online design.

- Controls in sidebar
- Theme'd the range input controls to match the online design
- Some very minor changes to the layout & basic styling (courier font)
- Permanently adds 2 mods instead of 1 example mod, allows for quicker dev (less copypasta while developing)
- Makes mod2 actually do something in the example blockstyle (changes stroke width)

I've had to add some wrapper divs and inline styling. If this bloats the index.js file I could seperate them out in index.js and index.css and use css classes to separate structure from styling.

Any other feedback, also welcome :)