### PR TITLE
feat: add Custom Attributes, misc: cleanup css

### DIFF
--- a/src/CustomStyle.js
+++ b/src/CustomStyle.js
@@ -40,6 +40,7 @@ const CustomStyle = ({
   color2 = '#c62a88',
   color3 = '#802d57',
   background = '#ccc',
+  attribsCallback
 }) => {
   const shuffleBag = useRef();
   const hoistedValue = useRef();
@@ -51,7 +52,6 @@ const CustomStyle = ({
     // Keep reference of canvas element for snapshots
     let _p5 = p5.createCanvas(width, height).parent(canvasParentRef);
     canvasRef.current = p5;
-
     attributesRef.current = () => {
       return {
         // This is called when the final image is generated, when creator opens the Mint NFT modal.
@@ -117,6 +117,8 @@ const CustomStyle = ({
         dot.radius * M * mod1
       );
     });
+
+    attribsCallback(attributesRef.current)
   };
 
   return <Sketch setup={setup} draw={draw} windowResized={handleResize} />;

--- a/src/components/ControlColorPicker.js
+++ b/src/components/ControlColorPicker.js
@@ -6,8 +6,8 @@ const ControlColorPicker = function (props) {
     }
 
     return (
-        <div style={{'margin': '5px 0', 'font-size': '11px'}}>
-            <label style={{'display': 'block', 'margin-bottom': '4px' }}>{props.controlLabel}</label>
+        <div>
+            <label className="Sidebar__ContentHeader">{props.controlLabel}</label>
             <input
                 id="controlColorPicker"
                 type="color"

--- a/src/components/ControlSlider.css
+++ b/src/components/ControlSlider.css
@@ -5,6 +5,7 @@
 
 .control-slider label {
   display: block;
+  font-weight: bold;
 }
 .control-slider .control-input {
   display: flex;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import blocks from './blocks';
 import CustomStyle from './CustomStyle';
 import ControlSlider from './components/ControlSlider';
 import ControlColorPicker from './components/ControlColorPicker';
+import './template.css';
 
 function App() {
   /*
@@ -16,6 +17,11 @@ function App() {
   const defaultMod1Value = 0.75;
   const defaultMod2Value = 0.25;
   const defaultBackgroundColor = '#cccccc';
+
+  const [customAttribs, setCustomAttribs] = useState([]);
+  function setAttribs(attributes) {
+    setCustomAttribs(attributes)
+  }
 
   const [blockNumber, setBlockNumber] = useState(defaultBlockNumber);
   const [mod1, setMod1] = useState(defaultMod1Value);
@@ -57,20 +63,15 @@ function App() {
               background={backgroundColor}
               mod1={mod1}
               mod2={mod2}
+              attribsCallback={setAttribs}
             />
           ) : null}
         </div>
       </div>
 
-      <div
-        style={{
-          width: '200px',
-          borderLeft: '#e0e0e0 1px solid',
-          backgroundColor: '#fff'
-        }}
-      >
-        <div style={{ height: '40px', background: '#000', color: '#fff', lineHeight: '40px', textAlign: 'center' }}>Change Block</div>
-        <div style={{ padding: '20px' }}>
+      <div className="Sidebar">
+        <div className="Sidebar__GroupHeader">Change Block</div>
+        <div className="Sidebar__Group">
           <ControlSlider
             modValue={blockNumber}
             modValueMin="1"
@@ -80,8 +81,8 @@ function App() {
           />
         </div>
 
-        <div style={{ height: '40px', background: '#000', color: '#fff', lineHeight: '40px', textAlign: 'center' }}>Change Style</div>
-        <div style={{ padding: '20px' }}>
+        <div className="Sidebar__GroupHeader">Change Style</div>
+        <div class="Sidebar__Group">
           {<ControlSlider
             controlLabel="mod1"
             modValue={mod1}
@@ -97,6 +98,16 @@ function App() {
             modValue={backgroundColor}
             onChange={(e) => { changeModValue(setBackgroundColor, e) }}
           />
+        </div>
+        <div className="Sidebar__GroupHeader">Custom Attributes</div>
+        <div className="Sidebar__Group">
+          {customAttribs.attributes ? 
+            customAttribs.attributes.map( (attribute, index) => {
+              return <div className="customAttribute">
+                  <div className="Sidebar__ContentHeader">{attribute.trait_type}</div>
+                  <div>{attribute.value}</div>
+                </div>
+            }) : ''}
         </div>
       </div>
     </div>

--- a/src/template.css
+++ b/src/template.css
@@ -1,0 +1,28 @@
+.Sidebar {
+  font-size: 11px;
+  width: 200px;
+  border-left: #e0e0e0 1px solid;
+  background-color: '#fff'
+}
+
+.CustomAttribute {
+  margin-bottom: 15px;
+}
+
+.Sidebar__GroupHeader {
+  height: 40px;
+  background: #000;
+  color: #fff;
+  line-height: 40px;
+  text-align: center
+}
+.Sidebar__Group {
+  font-weight: normal;
+  padding: 20px;
+}
+
+.Sidebar__ContentHeader {
+  display: block;
+  font-weight: bold;
+  margin: 5px 0;
+}


### PR DESCRIPTION
Add a callback for custom attributes to be shown under the mod controls. (I tried to figure out how to do it using the `attributesRef` ref from the parent but I couldn't, perhaps you know how.

+ Clean up some CSS